### PR TITLE
fix: Provider error test

### DIFF
--- a/CompletedSolution/Provider/tests/TestStartup.cs
+++ b/CompletedSolution/Provider/tests/TestStartup.cs
@@ -1,10 +1,9 @@
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using tests.Middleware;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 namespace tests
 {

--- a/CompletedSolution/Provider/tests/TestStartup.cs
+++ b/CompletedSolution/Provider/tests/TestStartup.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using tests.Middleware;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 namespace tests
 {
@@ -19,6 +20,11 @@ namespace tests
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<KestrelServerOptions>(options =>
+            {
+                options.AllowSynchronousIO = true;
+            });
+
             services.AddMvc();
         }
 


### PR DESCRIPTION
Pact is great but lost hours to figure out why Provider test was always failing. 

So here is the fix to issue #18 

Microsoft.AspNetCore.Server.Kestrel: Error: Connection id "0HM3LKBBJTAHT", Request id "0HM3LKBBJTAHT:00000001": An unhandled exception was thrown by the application.

System.InvalidOperationException: Synchronous operations are disallowed. Call ReadAsync or set AllowSynchronousIO to true instead.