### PR TITLE
Change reader to use async method

### DIFF
--- a/CompletedSolution/Provider/tests/Middleware/ProviderStateMiddleware.cs
+++ b/CompletedSolution/Provider/tests/Middleware/ProviderStateMiddleware.cs
@@ -77,7 +77,7 @@ namespace tests.Middleware
                 string jsonRequestBody = String.Empty;
                 using (var reader = new StreamReader(context.Request.Body, Encoding.UTF8))
                 {
-                    jsonRequestBody = reader.ReadToEnd();
+                    jsonRequestBody = reader.ReadToEndAsync().Result;
                 }
 
                 var providerState = JsonConvert.DeserializeObject<ProviderState>(jsonRequestBody);


### PR DESCRIPTION
This fixes the issue I raised (#20) whereby an exception is being thrown in the middleware. 