### PR TITLE
fix: issue#20 - Pact service fails when ProviderStateMiddleware uses reader.ReadToEnd

### DIFF
--- a/CompletedSolution/Provider/tests/Middleware/ProviderStateMiddleware.cs
+++ b/CompletedSolution/Provider/tests/Middleware/ProviderStateMiddleware.cs
@@ -58,7 +58,7 @@ namespace tests.Middleware
         {
             if (context.Request.Path.Value == "/provider-states")
             {
-                this.HandleProviderStatesRequest(context);
+                await this.HandleProviderStatesRequestAsync(context);
                 await context.Response.WriteAsync(String.Empty);
             }
             else
@@ -67,7 +67,7 @@ namespace tests.Middleware
             }
         }
 
-        private void HandleProviderStatesRequest(HttpContext context)
+        private async Task HandleProviderStatesRequestAsync(HttpContext context)
         {
             context.Response.StatusCode = (int)HttpStatusCode.OK;
 
@@ -77,7 +77,7 @@ namespace tests.Middleware
                 string jsonRequestBody = String.Empty;
                 using (var reader = new StreamReader(context.Request.Body, Encoding.UTF8))
                 {
-                    jsonRequestBody = reader.ReadToEnd();
+                    jsonRequestBody = await reader.ReadToEndAsync();
                 }
 
                 var providerState = JsonConvert.DeserializeObject<ProviderState>(jsonRequestBody);


### PR DESCRIPTION
This is a fix for issue #20 
`ProviderStateMiddleware.cs` uses `reader.ReadToEnd` which in runtime rises `Pact::ProviderVerifier::SetUpProviderStateError` exception. By making the reader _async_ the pact service is running fine.

There is a **slimier PR** (#21) which solves the error, but this one is more clean and with proper commit message format.